### PR TITLE
Added skip-frame functionality

### DIFF
--- a/xREgoPose/dataset/mocap_transformer.py
+++ b/xREgoPose/dataset/mocap_transformer.py
@@ -21,7 +21,7 @@ class MocapTransformer(BaseDataset):
     ROOT_DIRS = ['rgba', 'json']
     CM_TO_M = 100
 
-    def __init__(self, *args, sequence_length=5, skip =4, **kwargs):
+    def __init__(self, *args, sequence_length=5, skip =0, **kwargs):
         """Init class, to allow variable sequence length, inherits from Base
         Keyword Arguments:
             sequence_length -- length of image sequence (default: {5})


### PR DESCRIPTION
Sorry for the delay, this should be able to skip a designated number of frames.

What it's currently at with no skips: <br>
![image](https://user-images.githubusercontent.com/68381793/153688727-c0254042-e1b8-45c5-85ae-463937a96439.png) <br>
With Sequence Length 5 and No Skips: 16.4% frobenius norm of pixelwise error difference.

With 5 skips between each frame: <br>
![image](https://user-images.githubusercontent.com/68381793/153688835-d236d946-ce4c-4217-935f-ad0be13360c0.png) <br>
With Sequence Length 5 And 5 Skips: 39.2% frobenius norm of pixelwise error difference.

With 10 skips between each frame: <br>
![image](https://user-images.githubusercontent.com/68381793/153688977-3c686d28-630d-4c5f-a326-539c49ef933a.png) <br>
With Sequence Length 5 And 10 Skips: 48.5% frobenius norm of pixelwise error difference.

